### PR TITLE
Ahora los usuarios se pueden crear solo con el id

### DIFF
--- a/services/userService.ts
+++ b/services/userService.ts
@@ -1,7 +1,6 @@
 import { Callback, Context } from "aws-lambda";
 import { TABLE_NAME_USER } from "../constants";
 import { throwResponse } from "../utils/throwResponse";
-import { createAndUpdateUserValidations } from "../utils/validations";
 
 const AWS = require("aws-sdk"); // eslint-disable-line import/no-extraneous-dependencies
 
@@ -26,23 +25,8 @@ export const createUserService = (
   } = JSON.parse(event.body);
 
   if (!discord_id || typeof discord_id !== "string") {
-    responseMessage = "Bad Request: discord_id is required.";
+    responseMessage = "Bad Request: discord_id is required or is not a string.";
     return throwResponse(callback, responseMessage, 400);
-  }
-
-  const validationErrorMessage = createAndUpdateUserValidations(
-    discord_username,
-    full_name,
-    description,
-    email,
-    url_photo,
-    role,
-    links,
-    skills
-  );
-
-  if (validationErrorMessage) {
-    return throwResponse(callback, validationErrorMessage, 400);
   }
 
   const user = {
@@ -161,44 +145,50 @@ export const updateUserByIdService = (
   context: Context,
   callback: Callback<any>
 ): void => {
-  const { discord_username, full_name, description, email, url_photo, role, links, skills } =
-    JSON.parse(event.body);
+  const data = JSON.parse(event.body);
 
-  const validationErrorMessage = createAndUpdateUserValidations(
-    discord_username,
-    full_name,
-    description,
-    email,
-    url_photo,
-    role,
-    links,
-    skills
-  );
+  const generateUpdateQuery = (fields) => {
+    const allowedFieldsToUpdate = [
+      "discord_username",
+      "full_name",
+      "description",
+      "email",
+      "url_photo",
+      "role",
+      "links",
+      "skills",
+    ];
 
-  if (validationErrorMessage) {
-    return throwResponse(callback, validationErrorMessage, 400);
-  }
+    let expression = {
+      UpdateExpression: "set",
+      ExpressionAttributeNames: {},
+      ExpressionAttributeValues: {},
+    };
+
+    Object.entries(fields).forEach(([key, item]) => {
+      if (allowedFieldsToUpdate.includes(key)) {
+        expression.UpdateExpression += ` #${key} = :${key},`;
+        expression.ExpressionAttributeNames[`#${key}`] = key;
+        expression.ExpressionAttributeValues[`:${key}`] = item;
+      }
+    });
+
+    expression.UpdateExpression = expression.UpdateExpression.slice(0, -1);
+
+    if (Object.keys(expression.ExpressionAttributeNames).length === 0) {
+      responseMessage = "Bad Request: no valid fields to update.";
+      return throwResponse(callback, responseMessage, 400);
+    } else return expression;
+  };
+
+  let updateExpression = generateUpdateQuery(data);
 
   const params = {
     TableName: TABLE_NAME_USER,
     Key: { id: event.pathParameters.id },
-    ExpressionAttributeNames: {
-      "#role": "role",
-    },
-    ExpressionAttributeValues: {
-      ":discord_username": discord_username,
-      ":full_name": full_name,
-      ":description": description,
-      ":email": email,
-      ":role": role,
-      ":url_photo": url_photo,
-      ":skills": skills,
-      ":links": links,
-    },
     ConditionExpression: "attribute_exists(id)",
-    UpdateExpression:
-      "SET discord_username = :discord_username, full_name = :full_name, description = :description, email = :email, #role = :role, url_photo = :url_photo, skills = :skills, links = :links",
     ReturnValues: "ALL_NEW",
+    ...updateExpression,
   };
 
   dynamoDb.update(params, (error, data) => {


### PR DESCRIPTION
Ticket: https://app.clickup.com/t/1g58tqw
 
Ahora se puede crear usuarios solo con id y se quitaron las validaciones de campos que se decidió ya no estén:
![image](https://user-images.githubusercontent.com/47753872/136874871-3d7819ae-f630-45e5-82a1-64edcce3914d.png)

Si no hay id, devuelve bad request:
![image](https://user-images.githubusercontent.com/47753872/136874915-73f20d05-e8f6-4c1a-a1b2-8dfb0bedf68b.png)

Ahora también se puede usar el update para editar el o los campos que uno quiera, como me indicó Sebas.
Ejemplo editando solo el nombre:
![image](https://user-images.githubusercontent.com/47753872/138155542-a38921d2-2b13-4587-9054-1a6b28422ac0.png)





